### PR TITLE
Integrate GitHub MCP Server with Hello World Agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+.venv/
+.git/
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt /app/
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code into the container at /app
+COPY src/ /app/src/
+
+# GitHub MCP Server setup
+# Download and run the MCP server
+# This requires Docker to be available in the environment where this Dockerfile is built.
+# For now, we'll assume the MCP server is running separately or accessible via network.
+# We will need to provide the GITHUB_PERSONAL_ACCESS_TOKEN as an environment variable when running the container.
+
+# Make port 80 available to the world outside this container (if the agent needs to expose an HTTP server)
+# EXPOSE 80
+
+# Define environment variable
+ENV PYTHONUNBUFFERED 1
+ENV GITHUB_PERSONAL_ACCESS_TOKEN ""
+
+# Run agent.py when the container launches
+CMD ["python", "src/agent.py"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Prebid Agent Toolkit
 
-This project is a sample agent created with Python, using `uv` for package management and `mypy` for type checking.
+This project is a sample agent created with Python. It can be run locally or using Docker, with Docker being the primary method for interacting with the GitHub MCP Server.
 
-## Setup
+## Setup (For Local Development & Type Checking)
+
+These steps are relevant if you want to run the agent directly using Python for development or perform type checking.
 
 1.  **Clone the repository (if you haven't already):**
     ```bash
@@ -33,19 +35,70 @@ This project is a sample agent created with Python, using `uv` for package manag
     uv pip install -r requirements.txt
     ```
 
-## Running the Agent
+## Running the Agent with GitHub MCP Server (Docker)
 
-To run the sample agent:
+This agent can leverage the GitHub MCP Server to interact with GitHub APIs. This setup uses Docker to run both the agent and the MCP server.
+
+### Prerequisites
+
+*   **Docker**: Ensure Docker is installed and the Docker daemon is running.
+*   **GitHub Personal Access Token (PAT)**: You'll need a GitHub PAT. You can [create one here](https://github.com/settings/personal-access-tokens/new). The token will need permissions relevant to the tools you intend to use via the MCP server (e.g., `read:user` for the `get_me` tool).
+
+### Environment Variable
+
+The agent requires your GitHub PAT to be set as an environment variable for the Docker container that runs the agent:
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN="your_github_pat_here"
+```
+Make sure this variable is exported in the shell session from which you run the `docker run` command.
+
+### Build the Agent Docker Image
+
+Navigate to the project root directory and run:
+
+```bash
+docker build -t prebid-agent-mcp .
+```
+
+### Run the Agent
+
+To run the agent and have it interact with the MCP server, execute the following command:
+
+```bash
+docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN \
+    prebid-agent-mcp
+```
+
+**Explanation of the command:**
+*   `--rm`: Automatically removes the container when it exits.
+*   `-v /var/run/docker.sock:/var/run/docker.sock`: This mounts the Docker socket from your host into the container. It's **required** because the agent script itself executes `docker run` to start the `ghcr.io/github/github-mcp-server` Docker image.
+*   `-e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN`: This passes your GitHub PAT into the agent's container. The agent script then uses this token to authenticate when it, in turn, starts the MCP server container.
+*   `prebid-agent-mcp`: The name of the image you built.
+
+The agent will then start, invoke the GitHub MCP server (by running its Docker image), call the `get_me` tool via the MCP server, and print a greeting with your GitHub login and name.
+
+## Running the Agent Locally (Python directly)
+
+You can also run the agent directly using Python if you have set up your environment as described in the "Setup" section.
 
 ```bash
 python src/agent.py
 ```
 
-You should see the output: `Hello, World! This is your agent speaking.`
+**Note**: When run this way, the `src/agent.py` script will attempt to use `docker` commands to launch the MCP server (`ghcr.io/github/github-mcp-server`). This means:
+1.  Docker must be installed and the Docker daemon running.
+2.  The `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable must be set in your current shell session:
+    ```bash
+    export GITHUB_PERSONAL_ACCESS_TOKEN="your_github_pat_here"
+    ```
+If Docker is not available or the MCP server container cannot be launched, the agent will fail. The Dockerized setup described in the previous section is the primary and more robust method for running the agent with MCP integration, as it ensures the agent's execution environment is correctly configured.
 
 ## Type Checking
 
-To check types using mypy:
+To check types using mypy (ensure you've followed the "Setup" section first):
 
 ```bash
 mypy src/agent.py
@@ -56,5 +109,4 @@ mypy src
 ```
 
 The command should report `Success: no issues found` if everything is correctly typed.
-
-This project is a demonstration of a simple agent.
+This project demonstrates an agent interacting with the GitHub MCP server.

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,17 +1,142 @@
-import google.generativeai as genai
+import os
+import json
+import subprocess
 
 def run_agent() -> str:
     """
-    A simple agent that returns a greeting.
+    An agent that interacts with the GitHub MCP server via stdio to get user details.
     """
-    # In a real scenario, you might configure an API key here
-    # genai.configure(api_key="YOUR_API_KEY")
-    # For this example, we'll just return a string
-    # without making an API call.
+    token = os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("GITHUB_PERSONAL_ACCESS_TOKEN environment variable not set.")
 
-    greeting: str = "Hello, World! This is your agent speaking."
-    return greeting
+    # Command to run the MCP server in a Docker container
+    # The GitHub token is passed as an environment variable to the container
+    mcp_command = [
+        "docker", "run", "-i", "--rm", # -i for interactive (to use stdin), --rm to clean up
+        "-e", f"GITHUB_PERSONAL_ACCESS_TOKEN={token}",
+        "ghcr.io/github/github-mcp-server"
+    ]
+
+    # MCP request payload for the 'get_me' tool
+    # Following a more standard MCP structure for requests
+    request_payload = {
+        "mcp_version": "0.1.0",
+        "tool_invocation": {
+             "tool_name": "get_me",
+             "arguments": {}
+        }
+    }
+    # MCP messages are typically newline-delimited JSON
+    request_json = json.dumps(request_payload) + "\n"
+
+    stdout_data = "" # Initialize to ensure it's defined for error reporting
+    stderr_data = "" # Initialize to ensure it's defined for error reporting
+
+    try:
+        # Start the MCP server process and send the request to its stdin
+        # Read stdout and stderr until the process terminates
+        process = subprocess.Popen(
+            mcp_command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True # Work with text (UTF-8) streams
+        )
+
+        # Communicate sends input, waits for process to terminate, and returns output/error
+        stdout_data, stderr_data = process.communicate(input=request_json, timeout=60) # Increased timeout to 60s
+
+        if process.returncode != 0:
+            # MCP server process exited with an error
+            error_message = stderr_data.strip() if stderr_data.strip() else "Unknown error from MCP server process."
+            # Sometimes, error details might be on stdout if stderr is empty and process failed
+            if not stderr_data.strip() and stdout_data.strip():
+                error_message = stdout_data.strip()
+            return f"MCP Server process error (return code {process.returncode}): {error_message[:1000]}" # Limit error message length
+
+        if not stdout_data.strip():
+            # No output received on stdout, which is unexpected for a successful call
+            error_info = stderr_data.strip() if stderr_data.strip() else "No error message on stderr."
+            return f"No response from MCP server on stdout. Stderr: {error_info[:1000]}"
+
+        # MCP servers can send multiple JSON objects, newline-delimited.
+        # We need to parse the relevant JSON object that contains the tool result.
+        # It's often the last valid JSON object, or one that matches the "tool_result" structure.
+        parsed_response = None
+        last_json_decode_error = None
+
+        # Iterate through lines to find a valid MCP JSON response
+        # Prefer responses that contain 'tool_result' or 'error' keys.
+        candidate_lines = stdout_data.strip().splitlines()
+        for line in reversed(candidate_lines): # Check from last line first
+            if not line.strip():
+                continue
+            try:
+                current_json = json.loads(line)
+                if "tool_result" in current_json or "error" in current_json:
+                    parsed_response = current_json
+                    break
+                if parsed_response is None: # If no ideal MCP response yet, take the first valid JSON from end
+                    parsed_response = current_json
+            except json.JSONDecodeError as e:
+                if last_json_decode_error is None : # Store first decode error encountered from end
+                    last_json_decode_error = e
+
+        if parsed_response is None:
+            error_context = f"Raw stdout: {stdout_data.strip()[:500]}"
+            if last_json_decode_error:
+                 return f"Failed to find or parse a JSON response from MCP server. Last decode error: {last_json_decode_error}. {error_context}"
+            return f"No valid JSON response found in MCP server stdout. {error_context}"
+
+        response_data = parsed_response
+
+        # Check for MCP-level errors in the response
+        if "error" in response_data:
+            error_details = response_data.get("error", {})
+            return f"Error from MCP server: {error_details.get('message', 'Unknown MCP error')}. Details: {json.dumps(error_details)[:500]}"
+
+        # Expecting result in a "tool_result" field as per common MCP patterns
+        tool_result_wrapper = response_data.get("tool_result")
+        if not tool_result_wrapper:
+            if "login" in response_data and "id" in response_data:
+                 actual_result = response_data
+            else:
+                return f"Unexpected MCP response format. Missing 'tool_result' and response doesn't look like user data. Response: {json.dumps(response_data)[:500]}"
+        else:
+            actual_result = tool_result_wrapper.get("result")
+            if actual_result is None:
+                 return f"MCP tool result is missing or null within 'tool_result'. Full 'tool_result' content: {json.dumps(tool_result_wrapper)[:500]}"
+
+        user_login = actual_result.get("login", "N/A")
+        user_name = actual_result.get("name", "N/A")
+
+        return f"Hello, {user_login}! Your name is {user_name} (via MCP)."
+
+    except subprocess.TimeoutExpired:
+        stderr_content = stderr_data.strip()[:500] if stderr_data else 'N/A'
+        return f"MCP Server process timed out after 60s. This might happen if the Docker image needs to be pulled or the server is slow to start/process. Stderr: {stderr_content}"
+    except subprocess.SubprocessError as e:
+        return f"Failed to run/communicate with MCP server process: {e}"
+    except json.JSONDecodeError as e:
+        raw_output_for_error = stdout_data.strip()[:500] if stdout_data else "No stdout data captured."
+        return f"Error: Could not decode JSON response from MCP server (unexpectedly). Error: {e}. Received: '{raw_output_for_error}'"
+    except Exception as e:
+        return f"An unexpected error occurred: {type(e).__name__} - {e}"
 
 if __name__ == "__main__":
-    message: str = run_agent()
-    print(message)
+    print("Attempting to run agent...")
+    print("Please ensure Docker is running and you have set the GITHUB_PERSONAL_ACCESS_TOKEN environment variable.")
+    print("The agent will attempt to run 'ghcr.io/github/github-mcp-server' via Docker.")
+    print("This may take a moment if the Docker image needs to be pulled (timeout is 60s).")
+
+    try:
+        message = run_agent()
+        print("\n--- Agent Result ---")
+        print(message)
+    except ValueError as e:
+        print(f"\n--- Configuration Error ---")
+        print(f"{e}")
+    except Exception as e:
+        print(f"\n--- Agent Run Failed ---")
+        print(f"{type(e).__name__} - {e}")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,146 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+import subprocess # Required for subprocess.TimeoutExpired
+
+# Add src to path to allow direct import of agent
+# This allows running tests from the project root (e.g., python -m unittest discover tests)
+# or from the tests directory (e.g., python test_agent.py)
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+# The module to be tested
+import agent
+
+class TestAgent(unittest.TestCase):
+
+    @patch.dict(os.environ, {"GITHUB_PERSONAL_ACCESS_TOKEN": "test_token"})
+    @patch("subprocess.Popen")
+    def test_run_agent_success(self, mock_popen):
+        # Mock the Popen process object and its communicate method
+        mock_process = MagicMock() # This represents the Popen instance
+        mock_process.returncode = 0
+
+        # Expected MCP response payload for a successful 'get_me' tool call
+        mcp_response_payload = {
+            "tool_result": {
+                "tool_name": "get_me",
+                "result": {
+                    "login": "testuser",
+                    "name": "Test User",
+                    "id": 12345
+                }
+            }
+        }
+        # MCP server typically outputs newline-delimited JSON
+        stdout_data = json.dumps(mcp_response_payload) + "\n"
+        stderr_data = "" # No error output expected on stderr for success
+
+        # Configure the mock_process.communicate() method to return the expected stdout and stderr
+        mock_process.communicate.return_value = (stdout_data, stderr_data)
+
+        # Configure mock_popen (the Popen class) to return our mock_process instance when called
+        mock_popen.return_value = mock_process
+
+        # Run the agent function
+        result = agent.run_agent()
+
+        # Assert the agent's output
+        self.assertEqual(result, "Hello, testuser! Your name is Test User (via MCP).")
+
+        # Verify that subprocess.Popen was called correctly
+        expected_mcp_command = [
+            "docker", "run", "-i", "--rm",
+            "-e", "GITHUB_PERSONAL_ACCESS_TOKEN=test_token", # Token from patched os.environ
+            "ghcr.io/github/github-mcp-server"
+        ]
+        mock_popen.assert_called_once() # Check Popen was called
+        popen_call_args, popen_call_kwargs = mock_popen.call_args
+        self.assertEqual(popen_call_args[0], expected_mcp_command) # Check the command argument
+        self.assertTrue(popen_call_kwargs.get("text")) # Check a keyword argument like 'text=True'
+
+        # Verify the input sent to the MCP server process via communicate()
+        expected_input_payload = {
+            "mcp_version": "0.1.0",
+            "tool_invocation": {
+                "tool_name": "get_me",
+                "arguments": {}
+            }
+        }
+        expected_input_json = json.dumps(expected_input_payload) + "\n"
+        # Check that mock_process.communicate was called with the correct input and timeout
+        mock_process.communicate.assert_called_once_with(input=expected_input_json, timeout=60)
+
+    @patch.dict(os.environ, {}, clear=True) # Ensure a clean environment for this test
+    def test_run_agent_missing_token(self):
+        # Test the case where GITHUB_PERSONAL_ACCESS_TOKEN is not set
+        with self.assertRaisesRegex(ValueError, "GITHUB_PERSONAL_ACCESS_TOKEN environment variable not set."):
+            agent.run_agent()
+
+    @patch.dict(os.environ, {"GITHUB_PERSONAL_ACCESS_TOKEN": "test_token"})
+    @patch("subprocess.Popen")
+    def test_run_agent_mcp_process_error(self, mock_popen):
+        # Test MCP server process failure (e.g., Docker command fails)
+        mock_process = MagicMock()
+        mock_process.returncode = 1 # Non-zero return code indicates an error
+        # Simulate error message on stderr
+        mock_process.communicate.return_value = ("", "Docker error: MCP server failed to start")
+        mock_popen.return_value = mock_process
+
+        result = agent.run_agent()
+        self.assertEqual(result, "MCP Server process error (return code 1): Docker error: MCP server failed to start")
+
+    @patch.dict(os.environ, {"GITHUB_PERSONAL_ACCESS_TOKEN": "test_token"})
+    @patch("subprocess.Popen")
+    def test_run_agent_mcp_tool_error_response(self, mock_popen):
+        # Test MCP server returning a structured error in its JSON response
+        mock_process = MagicMock()
+        mock_process.returncode = 0 # Process itself succeeded
+
+        mcp_error_response_payload = {
+            "error": { # MCP standard error structure
+                "message": "Invalid token or insufficient permissions",
+                "code": 401 # Example error code
+            }
+        }
+        stdout_data = json.dumps(mcp_error_response_payload) + "\n"
+        mock_process.communicate.return_value = (stdout_data, "") # No stderr error
+        mock_popen.return_value = mock_process
+
+        result = agent.run_agent()
+        expected_error_details_json = json.dumps(mcp_error_response_payload['error'])[:500]
+        self.assertEqual(result, f"Error from MCP server: Invalid token or insufficient permissions. Details: {expected_error_details_json}")
+
+    @patch.dict(os.environ, {"GITHUB_PERSONAL_ACCESS_TOKEN": "test_token"})
+    @patch("subprocess.Popen")
+    def test_run_agent_mcp_timeout(self, mock_popen):
+        # Test timeout during communication with MCP server
+        mock_process = MagicMock()
+        # Configure communicate method to raise TimeoutExpired
+        mock_process.communicate.side_effect = subprocess.TimeoutExpired(cmd="docker run ...", timeout=60)
+        mock_popen.return_value = mock_process
+
+        result = agent.run_agent()
+        # The agent's error handler for TimeoutExpired uses stderr_data if available,
+        # which is initialized to "" in the agent and might not be updated if communicate fails early.
+        self.assertIn("MCP Server process timed out after 60s", result)
+        self.assertIn("Stderr: N/A", result) # Based on current agent error handling for timeout
+
+    @patch.dict(os.environ, {"GITHUB_PERSONAL_ACCESS_TOKEN": "test_token"})
+    @patch("subprocess.Popen")
+    def test_run_agent_json_decode_error(self, mock_popen):
+        # Test MCP server returning non-JSON output
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        stdout_data = "This is not valid JSON output\n" # Malformed or non-JSON string
+        mock_process.communicate.return_value = (stdout_data, "")
+        mock_popen.return_value = mock_process
+
+        result = agent.run_agent()
+        # Check for the specific error message from the agent's JSON parsing failure path
+        self.assertIn("Failed to find or parse a JSON response from MCP server.", result)
+        self.assertIn("Raw stdout: This is not valid JSON output", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit introduces integration with the GitHub MCP Server, allowing me to interact with GitHub APIs.

Key changes:
- Added a Dockerfile to containerize my environment. I now run the GitHub MCP server as a subprocess within my own Docker environment (ghcr.io/github/github-mcp-server).
- Modified `src/agent.py` so I can:
    - Retrieve `GITHUB_PERSONAL_ACCESS_TOKEN` from environment variables.
    - Launch the GitHub MCP server Docker container as a subprocess.
    - Communicate with the MCP server via stdio, sending a 'get_me' request.
    - Parse the MCP server's JSON response to display your information.
    - Includes error handling for process failures, timeouts, and invalid responses.
- Updated `requirements.txt` (though `requests` was already present).
- Significantly updated `README.md` to provide instructions for:
    - Setting up and running me using Docker.
    - Mounting the Docker socket (`/var/run/docker.sock`) which is crucial for my Docker container to be able to launch the MCP server's Docker container.
    - Setting the `GITHUB_PERSONAL_ACCESS_TOKEN`.
- Added `tests/test_agent.py` with unit tests that mock `subprocess.Popen` to cover various scenarios, including successful API calls, token errors, process failures, and malformed responses from the MCP server.

When run via the Docker setup, I will now use the MCP server's 'get_me' capability to fetch and display the authenticated GitHub user's login and name.